### PR TITLE
add execute permisssion 

### DIFF
--- a/lib/simple_provision/cli.rb
+++ b/lib/simple_provision/cli.rb
@@ -17,6 +17,7 @@ module SimpleProvision
       begin
         Net::SSH.start(host, username, :forward_agent => true) do |ssh|
           ssh.exec! "tar -xzf #{SimpleProvision::SCP::FILENAME}"
+          ssh.exec! "chmod +x scripts/*"
           scripts = options.fetch(:scripts).each do |script|
             puts "Execute #{script}"
             ssh.open_channel do |ssh_channel|

--- a/lib/simple_provision/scp.rb
+++ b/lib/simple_provision/scp.rb
@@ -38,6 +38,7 @@ module SimpleProvision
 
       cmds << "cd tmp && tar -czf #{FILENAME} files/ scripts/"
 
+
       if ENV["VERBOSE"]
         puts "==============Execute Locally============"
         puts cmds.join("\n")


### PR DESCRIPTION
The scripts failed to execute on remote server if they do not have execute rights

this fix adds execute permission on scripts after copying them in server before execute.
